### PR TITLE
Custom suricata-docker, fixed logstash, latest elk

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ volumes:
   pcap-storage: # store pcaps
 
 services:
-
   suricata:
     <<: *base
     # Reference:
@@ -34,7 +33,13 @@ services:
     # - https://github.com/dtag-dev-sec/tpotce/blob/master/docker/suricata/Dockerfile
     # - https://hub.docker.com/r/jasonish/suricata/
     # - https://github.com/StamusNetworks/suricata-docker/blob/master/Dockerfile
-    image: dtagdevsec/suricata:1804
+    image: suricata-selks
+    build:
+      context: ./suricata
+      args:
+        <<: *proxy
+        GIT_COMMIT: ${GIT_COMMIT}
+        BUILD_ID: ${BUILD_ID}
     network_mode: "host"
     cap_add:
      - NET_ADMIN
@@ -43,7 +48,6 @@ services:
     volumes:
       - ./suricata/config/suricata.yaml:/etc/suricata/suricata.yaml:ro
       - ./suricata/pcap:/pcap
-      #- ./suricata/config/ethtool.conf:/etc/supervisor/conf.d/ethtool.conf:ro
       - json-data:/var/log/suricata/
       - rules-data:/etc/suricata/rules/
       - ./suricata/rules/suricata.rules:/etc/suricata/rules/suricata.rules
@@ -99,7 +103,7 @@ services:
     <<: *base
     image: stamus/scirius:latest
     ports:
-       - "8080:8000"
+      - "8080:8000"
     volumes:
       - ./scirius/config:/etc/scirius:ro
       - rules-data:/etc/suricata/rules:rw
@@ -110,7 +114,7 @@ services:
     <<: *base
     image: jasonish/evebox:latest
     ports:
-       - "5636:5636"
+      - "5636:5636"
     depends_on:
       - elasticsearch
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
 
   elasticsearch:
     <<: *base
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.0
     ports: [ '9200:9200', '9300:9300' ]
     volumes: [ 'es-data:/usr/share/elasticsearch/data' ]
     environment:
@@ -76,7 +76,7 @@ services:
   logstash:
     <<: *base
     # cf.: https://www.elastic.co/guide/en/logstash/current/docker-config.html
-    image: docker.elastic.co/logstash/logstash-oss:6.2.4
+    image: docker.elastic.co/logstash/logstash-oss:6.3.0
     ports:
       - "5044:5044"
       - "9600:9600"
@@ -91,7 +91,7 @@ services:
 
   kibana:
     <<: *base
-    image: docker.elastic.co/kibana/kibana-oss:6.2.4
+    image: docker.elastic.co/kibana/kibana-oss:6.3.0
     ports: [ '5601:5601' ]
     depends_on: [ elasticsearch ]
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,16 +99,16 @@ services:
       SERVER_NAME: kibana.docker.selks
       ELASTICSEARCH_URL: http://elasticsearch:9200
 
-  scirius:
-    <<: *base
-    image: stamus/scirius:latest
-    ports:
-      - "8080:8000"
-    volumes:
-      - ./scirius/config:/etc/scirius:ro
-      - rules-data:/etc/suricata/rules:rw
-    environment:
-      <<: *proxy
+#  scirius:
+#    <<: *base
+#    image: stamus/scirius:latest
+#    ports:
+#      - "8080:8000"
+#    volumes:
+#      - ./scirius/config:/etc/scirius:ro
+#      - rules-data:/etc/suricata/rules:rw
+#    environment:
+#      <<: *proxy
 
   evebox:
     <<: *base

--- a/logstash/pipeline/logstash.conf
+++ b/logstash/pipeline/logstash.conf
@@ -3,12 +3,14 @@ input {
     path => ["/var/log/suricata/eve*.json"]
     codec => json
   }
+
 }
 
 filter {
   date {
     match => [ "timestamp", "ISO8601" ]
   }
+
   if [http] {
     useragent {
        source => "[http][http_user_agent]"
@@ -31,5 +33,7 @@ filter {
 }
 
 output {
-  hosts => ["elasticsearch:9200"]
+  elasticsearch {
+    hosts => elasticsearch
+  }
 }

--- a/logstash/pipeline/logstash.conf
+++ b/logstash/pipeline/logstash.conf
@@ -1,19 +1,14 @@
 input {
   file {
-    path => ["/var/log/suricata/*.json"]
+    path => ["/var/log/suricata/eve*.json"]
     codec => json
-    type => "Suricata"
   }
 }
 
 filter {
-  if [type] == "Suricata" {
-    date {
-      match => [ "timestamp", "ISO8601" ]
-    }
+  date {
+    match => [ "timestamp", "ISO8601" ]
   }
-
-
   if [http] {
     useragent {
        source => "[http][http_user_agent]"
@@ -24,25 +19,11 @@ filter {
   if [src_ip]  {
     geoip {
       source => "src_ip"
-      target => "geoip"
-      #database => "/opt/logstash/vendor/geoip/GeoLiteCity.dat"
-      add_field => [ "[geoip][coordinates]", "%{[geoip][longitude]}" ]
-      add_field => [ "[geoip][coordinates]", "%{[geoip][latitude]}"  ]
-    }
-    mutate {
-      convert => [ "[geoip][coordinates]", "float" ]
     }
     if ![geoip.ip] {
-      if [dest_ip]  {
+      if [dest_ip] {
         geoip {
           source => "dest_ip"
-          target => "geoip"
-          #database => "/opt/logstash/vendor/geoip/GeoLiteCity.dat"
-          add_field => [ "[geoip][coordinates]", "%{[geoip][longitude]}" ]
-          add_field => [ "[geoip][coordinates]", "%{[geoip][latitude]}"  ]
-        }
-        mutate {
-          convert => [ "[geoip][coordinates]", "float" ]
         }
       }
     }
@@ -50,7 +31,5 @@ filter {
 }
 
 output {
-  elasticsearch {
-    hosts => ["elasticsearch:9200"]
-  }
+  hosts => ["elasticsearch:9200"]
 }

--- a/suricata/Dockerfile
+++ b/suricata/Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:bionic
+
+ARG GIT_COMMIT=unknown
+ARG BUILD_ID=unknown
+ARG BUILD_DATE=unknown
+ARG BUILD_VERSION=0.1.0
+ARG NAME=suricata-profiling
+ARG VENDOR=awesome-inc
+ARG http_proxy
+ARG https_proxy
+
+# cf.: http://label-schema.org/rc1/
+LABEL org.label-schema.build-date="${BUILD_DATE}" \
+      org.label-schema.name="${NAME}" \
+      org.label-schema.description="Suricata docker container with enabled profiling and nfq" \
+      org.label-schema.vcs-url="https://github.com/awesome-inc/docker-selks.git" \
+      org.label-schema.vcs-ref="${GIT_COMMIT}" \
+      org.label-schema.vendor="${VENDOR}" \
+      org.label-schema.version="${BUILD_VERSION}" \
+      org.label-schema.schema-version="1.0"
+
+ENV GIT_COMMIT=$GIT_COMMIT
+ENV BUILD_ID=$BUILD_ID
+ENV http_proxy=$http_proxy
+ENV https_proxy=$https_proxy
+
+ADD config/ /etc/suricata/
+
+# Prerequisites as of https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Ubuntu_Installation_from_GIT
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install libpcre3 libpcre3-dbg libpcre3-dev \
+    build-essential autoconf automake libtool libpcap-dev libnet1-dev liblz4-dev \
+    libyaml-0-2 libyaml-dev pkg-config zlib1g zlib1g-dev libcap-ng-dev libcap-ng0 \
+    make libmagic-dev libjansson-dev git-core \
+    libnetfilter-queue-dev libnetfilter-queue1 libnfnetlink-dev libnfnetlink0 \
+    ca-certificates curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add user and group
+RUN addgroup --gid 2000 suri && \
+    adduser --system --uid 2000 --gid 2000 suri && \
+# build with nfq support, profiling support and also download emerging threats (thanks to make install-full)
+   git clone https://github.com/OISF/suricata.git && cd suricata && \
+   git clone https://github.com/OISF/libhtp.git -b 0.5.x && \
+   ./autogen.sh && \
+   ./configure --enable-profiling --enable-nfqueue --prefix=/usr --sysconfdir=/etc --localstatedir=/var && \
+# --enable-rust  # not working yet
+    make && make install-full && \
+    cd .. && rm -rf /suricata/
+
+CMD ["suricata", "-c", "/etc/suricata/suricata.yaml", "-i", "eth0"]


### PR DESCRIPTION
Fixes #1, #6, #7.

The docker container for suricata pulls directly from their github repository, as we need to build suricata ourselves with `--enable-profiling`.

Suricata output with `suricata -c /path/to/config --pcap-file-continuous -r ./` still shows no alerts, the EVE files, however, are correctly written and parsed by logstash.

Scirius has been disabled for now, as it throws exceptions we cannot do anything about.